### PR TITLE
Build using latest Jekyll image, fix mount paths

### DIFF
--- a/script/build
+++ b/script/build
@@ -4,16 +4,16 @@ set -e # halt script on error
 docker run \
   -it --rm --label=jekyll \
   --volume=$(pwd):/srv/jekyll \
-  jekyll/jekyll:3.5 bash -c "bundle install; bundle exec jekyll build"
+  jekyll/jekyll:3.8 bash -c "bundle install; bundle exec jekyll build"
 
 docker run \
   -it --rm --label=html-proofer \
-  --volume=$(pwd)/_deploy:/srv/site \
+  --volume=$(pwd)/_site:/srv/site \
   18fgsa/html-proofer /srv/site --disable-external --url-ignore "/^#$/" \
   || echo "Fail!"
 
 docker run \
   -it --rm --label=html5validator \
-  --volume=$(pwd)/_deploy:/mnt/site \
+  --volume=$(pwd)/_site:/app/site \
   stratdat/html5validator \
   || echo "Fail!"


### PR DESCRIPTION
* Use latest Jekyll (v3.8) image (same version used by our TravisCI setup when publishing the docs)
* Fix mount path for html-proofer run
* Fix mount path for html5validator run