### PR TITLE
Force doc link to open in new target

### DIFF
--- a/_source/_posts/2018-12-21-Update-to-the-PMHC-MDS-v-0-25-8-and-Data-Specifications-v1-0-13.md
+++ b/_source/_posts/2018-12-21-Update-to-the-PMHC-MDS-v-0-25-8-and-Data-Specifications-v1-0-13.md
@@ -21,7 +21,7 @@ The following updates and bug fixes have been implemented in the upload interfac
 * Fixed a bug where an error was not being correctly generated for ABNs that were 11 characters long but included whitespace
 * Fixed a bug where an upload format of PMHC 1.0 was incorrectly being reported for non PMHC 1.0 uploads early in the upload process
 
-The user guide has been updated to reflect these updates. It is available at [https://docs.pmhc-mds.com/user-documentation/](https://docs.pmhc-mds.com/user-documentation/).
+The user guide has been updated to reflect these updates. It is available at [https://docs.pmhc-mds.com/user-documentation/](https://docs.pmhc-mds.com/user-documentation/){:target="_blank"}.
 
 #### PMHC MDS Data Specifications Update v1.0.13 ####
 


### PR DESCRIPTION
PMHC FE tests check all links open in a blank window. As this content gets
included on the HOME tab, the link to the updated docs was causing tests
to fail. Force that link to open in a blank window.