### PR TITLE
More build cleanups

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -26,7 +26,7 @@ jobs:
 
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
@@ -68,4 +68,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2' # Not needed with a .ruby-version file
+          ruby-version: '3.4' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,7 @@ source 'https://rubygems.org'
 gem "jekyll", ">= 3.8.4"
 gem "ffi", ">= 1.9.24"
 gem 'html-proofer'
+# ruby 3.2 support
+gem "console", ">= 1.29", "<1.35"
 #gem 'jekyll-tagging'
 #gem 'jekyll-paginate'

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,5 @@ source 'https://rubygems.org'
 gem "jekyll", ">= 3.8.4"
 gem "ffi", ">= 1.9.24"
 gem 'html-proofer'
-# ruby 3.2 support
-gem "console", ">= 1.29", "<1.35"
 #gem 'jekyll-tagging'
 #gem 'jekyll-paginate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
     bigdecimal (4.1.2)
     colorator (1.1.0)
     concurrent-ruby (1.3.8)
-    console (1.37.0)
+    console (1.34.3)
       fiber-annotation
       fiber-local (~> 1.1)
       json
@@ -27,12 +27,21 @@ GEM
       logger
     eventmachine (1.2.7)
     ffi (1.17.4)
+    ffi (1.17.4-arm-linux-gnu)
+    ffi (1.17.4-arm64-darwin)
+    ffi (1.17.4-x86_64-linux-gnu)
     fiber-annotation (0.2.0)
     fiber-local (1.1.0)
       fiber-storage
     fiber-storage (1.0.1)
     forwardable-extended (2.6.0)
     google-protobuf (4.35.1)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-arm64-darwin)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-x86_64-linux-gnu)
       bigdecimal
       rake (~> 13.3)
     hashery (2.1.2)
@@ -89,6 +98,12 @@ GEM
     nokogiri (1.19.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    nokogiri (1.19.4-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.4-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.4-x86_64-linux-gnu)
+      racc (~> 1.4)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     pdf-reader (2.15.1)
@@ -111,6 +126,12 @@ GEM
     sass-embedded (1.102.0)
       google-protobuf (~> 4.31)
       rake (>= 13)
+    sass-embedded (1.102.0-arm-linux-gnueabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.102.0-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.102.0-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     ttfunk (1.7.0)
@@ -122,9 +143,13 @@ GEM
     zeitwerk (2.8.2)
 
 PLATFORMS
+  arm-linux-gnu
+  arm64-darwin
   ruby
+  x86_64-linux-gnu
 
 DEPENDENCIES
+  console (>= 1.29, < 1.35)
   ffi (>= 1.9.24)
   html-proofer
   jekyll (>= 3.8.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
     bigdecimal (4.1.2)
     colorator (1.1.0)
     concurrent-ruby (1.3.8)
-    console (1.34.3)
+    console (1.37.0)
       fiber-annotation
       fiber-local (~> 1.1)
       json
@@ -149,7 +149,6 @@ PLATFORMS
   x86_64-linux-gnu
 
 DEPENDENCIES
-  console (>= 1.29, < 1.35)
   ffi (>= 1.9.24)
   html-proofer
   jekyll (>= 3.8.4)


### PR DESCRIPTION
We were using Ruby 3.2 in the github action run, which is no longer supported by some the the gems required. Update the build to use Ruby 3.4 (same version in the Jekyll image).

Also updated the github actions used for node24 support.
